### PR TITLE
Convert testlist to version 2 format, add wallclock/comments, remove yellowstone

### DIFF
--- a/cime_config/testdefs/testlist_mosart.xml
+++ b/cime_config/testdefs/testlist_mosart.xml
@@ -5,6 +5,8 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="mosart"></machine>
       <machine name="cheyenne" compiler="gnu" category="mosart"></machine>
+      <machine name="cheyenne" compiler="intel" category="aux_clm"></machine>
+      <machine name="cheyenne" compiler="gnu" category="aux_clm"></machine>
       <machine name="hobart" compiler="nag" category="mosart"></machine>
       <options>
         <option name="wallclock">0:20</option>
@@ -15,6 +17,7 @@
   <test name="ERS_Ld5" grid="f10_f10_musgs" compset="I2000Clm50BgcCru" testmods="mosart/iceOff">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+      <machine name="cheyenne" compiler="intel" category="aux_clm"></machine>
       <options>
         <option name="wallclock">0:20</option>
       </options>
@@ -23,6 +26,7 @@
   <test name="ERS_Ld5" grid="f10_f10_musgs" compset="I2000Clm50BgcCru" testmods="mosart/mosartOff">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+      <machine name="cheyenne" compiler="intel" category="aux_clm"></machine>
       <options>
         <option name="wallclock">0:20</option>
       </options>
@@ -33,6 +37,8 @@
       <machine name="cheyenne" compiler="intel" category="mosart"></machine>
       <machine name="cheyenne" compiler="gnu" category="mosart"></machine>
       <machine name="hobart" compiler="nag" category="mosart"></machine>
+      <machine name="cheyenne" compiler="intel" category="aux_clm"></machine>
+      <machine name="cheyenne" compiler="gnu" category="aux_clm"></machine>
       <options>
         <option name="wallclock">0:20</option>
         <option name="comment"  >Smoke test with DEBUG on all machines/compilers</option>

--- a/cime_config/testdefs/testlist_mosart.xml
+++ b/cime_config/testdefs/testlist_mosart.xml
@@ -1,19 +1,42 @@
 <?xml version="1.0"?>
-<testlist>
-  <compset name="I2000Clm50BgcCru">
-    <grid name="f10_f10">
-      <test name="ERS_Ld5">
-        <machine compiler="gnu" testtype="mosart" testmods="mosart/default">yellowstone</machine>
-        <machine compiler="intel" testtype="mosart" testmods="mosart/default">yellowstone</machine>
-        <machine compiler="intel" testtype="mosart" testmods="mosart/iceOff">yellowstone</machine>
-        <machine compiler="intel" testtype="mosart" testmods="mosart/mosartOff">yellowstone</machine>
-        <machine compiler="pgi" testtype="mosart" testmods="mosart/default">yellowstone</machine>
-      </test>
-      <test name="SMS_D_Ld5">
-        <machine compiler="gnu" testtype="mosart" testmods="mosart/default">yellowstone</machine>
-        <machine compiler="intel" testtype="mosart" testmods="mosart/default">yellowstone</machine>
-        <machine compiler="pgi" testtype="mosart" testmods="mosart/default">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
+<testlist version="2.0">
+
+  <test name="ERS_Ld5" grid="f10_f10_musgs" compset="I2000Clm50BgcCru" testmods="mosart/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+      <machine name="cheyenne" compiler="gnu" category="mosart"></machine>
+      <machine name="hobart" compiler="nag" category="mosart"></machine>
+      <options>
+        <option name="wallclock">0:20</option>
+        <option name="comment"  >Restart test without DEBUG on all machines/compilers</option>
+      </options>
+    </machines>
+  </test>
+  <test name="ERS_Ld5" grid="f10_f10_musgs" compset="I2000Clm50BgcCru" testmods="mosart/iceOff">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+      <options>
+        <option name="wallclock">0:20</option>
+      </options>
+    </machines>
+  </test>
+  <test name="ERS_Ld5" grid="f10_f10_musgs" compset="I2000Clm50BgcCru" testmods="mosart/mosartOff">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+      <options>
+        <option name="wallclock">0:20</option>
+      </options>
+    </machines>
+  </test>
+  <test name="SMS_D_Ld5" grid="f10_f10_musgs" compset="I1850Clm50BgcCru" testmods="mosart/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+      <machine name="cheyenne" compiler="gnu" category="mosart"></machine>
+      <machine name="hobart" compiler="nag" category="mosart"></machine>
+      <options>
+        <option name="wallclock">0:20</option>
+        <option name="comment"  >Smoke test with DEBUG on all machines/compilers</option>
+      </options>
+    </machines>
+  </test>
 </testlist>

--- a/cime_config/testdefs/testlist_mosart.xml
+++ b/cime_config/testdefs/testlist_mosart.xml
@@ -28,7 +28,7 @@
       </options>
     </machines>
   </test>
-  <test name="SMS_D_Ld5" grid="f10_f10_musgs" compset="I1850Clm50BgcCru" testmods="mosart/default">
+  <test name="SMS_D_Ld5" grid="f10_f10_musgs" compset="I1850Clm50Bgc" testmods="mosart/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mosart"></machine>
       <machine name="cheyenne" compiler="gnu" category="mosart"></machine>

--- a/cime_config/testdefs/testlist_mosart.xml
+++ b/cime_config/testdefs/testlist_mosart.xml
@@ -45,4 +45,21 @@
       </options>
     </machines>
   </test>
+  <test name="SMS_D" grid="f10_f10_musgs" compset="I1850Clm50Bgc" testmods="mosart/decompOpts">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+      <options>
+        <option name="wallclock">0:20</option>
+        <option name="comment"  >decompOpts are not bit for bit on PE layout change</option>
+      </options>
+    </machines>
+  </test>
+  <test name="ERP_D" grid="f10_f10_musgs" compset="I1850Clm50Bgc" testmods="mosart/qgrwlOpts">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+      <options>
+        <option name="wallclock">0:20</option>
+      </options>
+    </machines>
+  </test>
 </testlist>

--- a/cime_config/testdefs/testmods_dirs/mosart/decompOpts/user_nl_mosart
+++ b/cime_config/testdefs/testmods_dirs/mosart/decompOpts/user_nl_mosart
@@ -1,0 +1,2 @@
+ smat_option = 'opt'
+ decomp_option = '1d'

--- a/cime_config/testdefs/testmods_dirs/mosart/qgrwlOpts/user_nl_mosart
+++ b/cime_config/testdefs/testmods_dirs/mosart/qgrwlOpts/user_nl_mosart
@@ -1,0 +1,2 @@
+ qgwl_runoff_option = 'all'
+ bypass_routing_option = 'direct_to_outlet'

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,20 @@
 ===============================================================
+Tag name:  mosart1_0_29
+Originator(s): erik
+Date: Jan 17, 2017
+One-line Summary:  Update testlist to version 2 format, remove ys tests
+
+ Add buildnmlc to .gitignore
+
+Convert the test list to version 2 format, add comments and wallclock to it.
+Remove ys tests. Remove aux_clm tests (put those in CLM itself).  Add
+two more test mods for currently untested options.
+
+ M cime_config/testdefs/testlist_mosart.xml
+ A cime_config/testdefs/testmods_dirs/mosart/decompOpts/user_nl_mosart
+ A cime_config/testdefs/testmods_dirs/mosart/qgrwlOpts/user_nl_mosart
+
+===============================================================
 Tag name:  mosart1_0_28
 Originator(s): erik
 Date: Oct 05, 2017


### PR DESCRIPTION
Convert the test list to version 2 format, add comments and wallclock to it.
Remove ys tests. Remove aux_clm tests (put those in CLM itself).