### PR TITLE
Don't allow single precision history output

### DIFF
--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -261,13 +261,13 @@
     <type>integer(6)</type> 
     <category>history</category>
     <group>mosart_inparm</group> 
-    <valid_values>1,2</valid_values>
+    <valid_values>1</valid_values>
     <values>
-      <value>2</value>
+      <value>1</value>
     </values>
     <desc>
       Per tape series  history file density (i.e. output precision) 
-      1=double precision, 2=single precision
+      1=double precision, 2=single precision (NOT working)
     </desc>
   </entry>
 

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,14 +1,12 @@
 ===============================================================
 Tag name:  release-cesm2.0.03
 Originator(s): erik
-Date: Oct 18, 2018
+Date: Oct 19, 2018
 One-line Summary: Remove ability to write out single-precision history because of issues
 
 Don't allow the namelist option rtmhist_ndens to be set to 2, because this
 option doesn't currently function. The simple fix we put into place for it
-is not robust, and doesn't show conversion issues as soon as possible. We
-need to implement a solution that keeps history buffers at single precision
-and converts the instantaneous double precision data as it goes.
+is not robust.
 
 MOSART Master Tag This Corresponds To: mosart1_0_31 (with changes)
 
@@ -28,11 +26,10 @@ Pull Requests that document the changes (include PR ids):
 
  #19 -- Don't allow single precision history output
 
-Testing:
 ===============================================================
 Tag name:  release-cesm2.0.02
 Originator(s): erik/billsacks
-Date: Oct 12, 2018
+Date: Oct 16, 2018
 One-line Summary:  Fix for py3 
 
 MOSART Master Tag This Corresponds To: mosart1_0_31 (with changes)
@@ -49,7 +46,9 @@ Pull Requests that document the changes (include PR ids):
 
  #17 -- Changes to fix #10, where an integer divide needs the floor operator
 
-Testing:
+Testing: Run mosart test suite
+   hobart ---- PASS
+   cheyenne -- PASS
 
 ===============================================================
 Tag name:  release-cesm2.0.01

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -32,6 +32,8 @@ Originator(s): erik/billsacks
 Date: Oct 16, 2018
 One-line Summary:  Fix for py3 
 
+Fix for python3, using the floor operator for integer division.
+
 MOSART Master Tag This Corresponds To: mosart1_0_31 (with changes)
 
 Issues Fixed: #10

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,4 +1,35 @@
 ===============================================================
+Tag name:  release-cesm2.0.03
+Originator(s): erik
+Date: Oct 18, 2018
+One-line Summary: Remove ability to write out single-precision history because of issues
+
+Don't allow the namelist option rtmhist_ndens to be set to 2, because this
+option doesn't currently function. The simple fix we put into place for it
+is not robust, and doesn't show conversion issues as soon as possible. We
+need to implement a solution that keeps history buffers at single precision
+and converts the instantaneous double precision data as it goes.
+
+MOSART Master Tag This Corresponds To: mosart1_0_31 (with changes)
+
+Issues Fixed: #10
+  #18 -- rtmhist_ndens=2 does NOT work (so don't allow it as an option)
+
+Science  changes since: release-cesm2.0.01 
+   * None
+Software changes since: release-cesm2.0.01
+   * None
+
+Testing: Run mosart test suite
+   hobart ---- PASS
+   cheyenne -- PASS
+
+Pull Requests that document the changes (include PR ids):
+
+ #19 -- Don't allow single precision history output
+
+Testing:
+===============================================================
 Tag name:  release-cesm2.0.02
 Originator(s): erik/billsacks
 Date: Oct 12, 2018
@@ -33,6 +64,9 @@ will read in PIO_DOUBLE for input xtype= PIO_DOUBLE or PIO_REAL. Most of this
 is direct from jedwards4b (other than r8th addition).
 
 MOSART Master Tag This Corresponds To: mosart1_0_31 (with changes)
+
+Issues Fixed: #18
+  #18 -- rtmhist_ndens=2 does NOT work (simplest fix that converts to single on output)
 
 Science  changes since: release-cesm2.0.00
    Added in 8th degree routing file (r8th)

--- a/src/riverroute/RtmHistFile.F90
+++ b/src/riverroute/RtmHistFile.F90
@@ -42,7 +42,7 @@ module RtmHistFile
 !
   integer :: ni
   integer, public :: &
-       rtmhist_ndens(max_tapes) = 2         ! namelist: output density of netcdf history files
+       rtmhist_ndens(max_tapes) = 1         ! namelist: output density of netcdf history files
   integer, public :: &
        rtmhist_mfilt(max_tapes) = 30        ! namelist: number of time samples per tape
   integer, public :: &

--- a/src/riverroute/RtmIO.F90
+++ b/src/riverroute/RtmIO.F90
@@ -1827,7 +1827,7 @@ contains
           call pio_setframe(ncid,vardesc, int(nt,kind=PIO_Offset_kind))
        end if
        if(xtype == ncd_float) then
-          call pio_write_darray(ncid, vardesc, iodesc_plus%iodesc, real(data, kind=r4), status, fillval=real(spval,kind=r4))
+          call shr_sys_abort( subname//' error: Attempt to write out single-precision data which is current NOT implemented (see issue #18)' )
        else
           call pio_write_darray(ncid, vardesc, iodesc_plus%iodesc, data, status, fillval=spval)
        endif


### PR DESCRIPTION
Don't allow single precision history output to be an option until a better solution is implemented. The current solution was to convert to single precision on output, but that has two problems it delays conversion errors until history is written, and it's been shown to not be as robust as keeping single precision history buffers in place.