### PR TITLE
Add support for regional NLDAS grid

### DIFF
--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -166,7 +166,7 @@
     <group>mosart_inparm</group> 
     <values>
       <value rof_grid="r05">$DIN_LOC_ROOT/rof/mosart/MOSART_routing_Global_0.5x0.5_c170601.nc</value>
-      <value rof_grid="r0.125nldas2">$DIN_LOC_ROOT/rof/mosart/MOSART_routing_0.125nldas2_c190412.nc</value>
+      <value rof_grid="0.125nldas2">$DIN_LOC_ROOT/rof/mosart/MOSART_routing_0.125nldas2_c190415.nc</value>
     </values>
     <desc>
       Full pathname of input datafile for RTM.

--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -166,6 +166,7 @@
     <group>mosart_inparm</group> 
     <values>
       <value rof_grid="r05">$DIN_LOC_ROOT/rof/mosart/MOSART_routing_Global_0.5x0.5_c170601.nc</value>
+      <value rof_grid="r0.125nldas2">$DIN_LOC_ROOT/rof/mosart/MOSART_routing_0.125nldas2_c190412.nc</value>
     </values>
     <desc>
       Full pathname of input datafile for RTM.


### PR DESCRIPTION
This PR adds support for a regional, 1/8 deg grid over the NLDAS domain - the Continental U.S. plus a little surrounding area.

@swensosc created the input file by subsetting the global 1/8 deg MOSART input file. I then renumbered IDs using the attached script. (Note that, for points whose downstream point is outside the subset grid, I assigned them a downstream ID of -9999.)
[mosart_renumber.py.txt](https://github.com/ESCOMP/mosart/files/3085533/mosart_renumber.py.txt)

