### PR TITLE
remove nuopc_cap_share from build (done in csm_share)

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -41,8 +41,6 @@ def _build_mosart():
             paths = [ os.path.join(caseroot,"SourceMods","src.mosart"),
                       os.path.join(srcroot,"components","mosart","src","riverroute"),
                       os.path.join(srcroot,"components","mosart","src","cpl",driver)]
-            if driver == 'nuopc':
-                paths.append(os.path.join(srcroot,"cime","src","drivers","nuopc","nuopc_cap_share"))
 
             with open(filepath_file, "w") as filepath:
                 filepath.write("\n".join(paths))


### PR DESCRIPTION
As of cime 9db73e46 the nuopc_cap code is built as part of csm_share instead of by individual components. 