### PR TITLE
Change shebang lines, abort if direction file not set, add a compset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ core.*
 *.gz
 *.log
 cime_config/buildnmlc
+__pycache__
 
 # test and case directories
 tests/

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Build the mosart component library
 """

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Namelist creator for CIME's data atmosphere model.
 """

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -120,6 +120,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         coupling_period = basedt // mosart_ncpl
     nmlgen.set_value("coupling_period", value=coupling_period)
 
+    if ( nmlgen.get_value("frivinp_rtm") == "UNSET" ):
+        raise SystemExit("ERROR: Direction file is NOT set and is required: frivinp_rtm")
+
     #----------------------------------------------------
     # Write output file
     #----------------------------------------------------

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<compsets version="2.0">
+
+  <help>
+    =========================================
+    compset naming convention
+    =========================================
+    The compset longname below has the specified order
+    atm, lnd, ice, ocn, river, glc wave cesm-options
+
+    The notation for the compset longname is
+    TIME_ATM[%phys]_LND[%phys]_ICE[%phys]_OCN[%phys]_ROF[%phys]_GLC[%phys]_WAV[%phys][_BGC%phys]
+    Where for the CAM specific compsets below the following is supported
+    TIME = Time period (e.g. 2000, HIST, RCP8...)
+    ATM  = [CAM40, CAM50, CAM55, CAM60]
+    LND  = [CLM45, CLM50, DLND, SLND]
+    ICE  = [CICE, DICE, SICE]
+    OCN  = [DOCN, SOCN, POP2, MOM]
+    ROF  = [RTM, MOSART, MIZUROUTE, DROF, SROF]
+    GLC  = [CISM1, CISM2, SGLC]
+    WAV  = [SWAV, WWW]
+    BGC  = optional BGC scenario
+
+    The OPTIONAL %phys attributes specify submodes of the given system
+    For example DOCN%DOM is the data ocean model for DOCN
+    ALL the possible %phys choices for each component are listed
+    with the -list command for create_newcase
+    ALL data models must have a %phys option that corresponds to the data  model mode
+
+    Each compset node is associated with the following elements
+    - lname
+    - alias
+    - science_support  (if this compset is supported scientifically with control simulations)
+  </help>
+
+  <!-- R compsets -->
+
+  <compset>
+    <alias>R2000MOSART</alias>
+    <lname>2000_SATM_DLND%LCPL_SICE_SOCN_MIZUROUTE_SGLC_SWAV</lname>
+  </compset>
+
+</compsets>

--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -165,6 +165,7 @@
     <input_pathname>abs</input_pathname>
     <group>mosart_inparm</group>
     <values>
+      <value                       >UNSET</value>
       <value rof_grid="r05"        >$DIN_LOC_ROOT/rof/mosart/MOSART_routing_Global_0.5x0.5_c170601.nc</value>
       <value rof_grid="r8th"       >$DIN_LOC_ROOT/rof/mosart/MOSART_Global_8th_20191007.nc</value>
       <value rof_grid="0.125nldas2">$DIN_LOC_ROOT/rof/mosart/MOSART_routing_0.125nldas2_cdf5_c200727.nc</value>

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,4 +1,20 @@
 ===============================================================
+Tag name:  mosart1_0_43
+Originator(s): erik
+Date: July 16, 2021
+One-line Summary: Change shebang lines to python3, abort if direction file not set, add compset
+
+Change the shebang lines in buildnml and buildlib for python3
+Abort if a direction file is not set
+Add a compset for running MOSART on it's own (not tested yet)
+
+Fixes #42 -- Change shebang lines for python
+Fixes #35 -- point to directory
+Fixes #28 -- add R2000MOSART compset
+
+See https://github.com/ESCOMP/MOSART/pull/43
+
+===============================================================
 Tag name:  mosart1_0_42
 Originator(s): jedwards
 Date: April 5, 2021


### PR DESCRIPTION
Change the shebang lines in buildnml and buildlib for python3
Abort if a direction file is not set
Add a compset for running MOSART on it's own (not tested yet)

Fixes #42 -- Change shebang lines for python
Fixes #35 -- point to directory
Fixes #28 -- add R2000MOSART compset