### PR TITLE
Bug fix for bypass_routing_option = 'direct_to_outlet' method

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -9,7 +9,7 @@ import os, sys
 CIMEROOT = os.environ.get("CIMEROOT")
 if CIMEROOT is None:
     raise SystemExit("ERROR: must set CIMEROOT environment variable")
-sys.path.append(os.path.join(CIMEROOT, "scripts", "Tools"))
+sys.path.append(os.path.join(CIMEROOT, "scripts", "CIME", "Tools"))
 
 from standard_script_setup import *
 from CIME.case import Case

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -134,6 +134,14 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     if ( nmlgen.get_value("frivinp_rtm") == "UNSET" and config["mosart_mode"] != "NULL" ):
         raise SystemExit("ERROR: Direction file is NOT set and is required when MOSART is active: frivinp_rtm")
 
+    bypass_routing_option = nmlgen.get_value("bypass_routing_option")
+    qgwl_runoff_option    = nmlgen.get_value("qgwl_runoff_option")
+    if bypass_routing_option == "none" and qgwl_runoff_option != "all":
+        raise SystemExit("ERROR: When bypass_routing_option is none, qgwl_runoff_option can only be all")
+
+    if bypass_routing_option == "direct_to_outlet" and qgwl_runoff_option == "threshold":
+        raise SystemExit("ERROR: When bypass_routing_option is direct_to_outlet, qgwl_runoff_option can not be threshold")
+
     #----------------------------------------------------
     # Write output file
     #----------------------------------------------------

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -14,7 +14,7 @@ import os, shutil, sys
 CIMEROOT = os.environ.get("CIMEROOT")
 if CIMEROOT is None:
     raise SystemExit("ERROR: must set CIMEROOT environment variable")
-sys.path.append(os.path.join(CIMEROOT, "scripts", "Tools"))
+sys.path.append(os.path.join(CIMEROOT, "scripts", "CIME", "Tools"))
 
 from standard_script_setup import *
 from CIME.case import Case

--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -111,6 +111,7 @@
     </values>
     <desc>
       Method for handling of qgwl runoff inputs.
+      (threshold is only valid for bypass_routing_option=direct_in_place)
     </desc>
   </entry>
 

--- a/cime_config/testdefs/testlist_mosart.xml
+++ b/cime_config/testdefs/testlist_mosart.xml
@@ -100,7 +100,7 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment"  >Pass channel depths needed for hillslope model (will fail until you use a version of CMEPS with this)</option>
+      <option name="comment"  >Pass channel depths needed for hillslope model</option>
     </options>
   </test>
   <test name="ERP_D" grid="f10_f10_mg37" compset="I1850Clm50Bgc" testmods="mosart/qgrwlOpts">
@@ -109,6 +109,15 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
+    </options>
+  </test>
+  <test name="PEM_D" grid="f10_f10_mg37" compset="I1850Clm50Sp" testmods="mosart/negtooutlet">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Set direct_to_outlet for negative flow</option>
     </options>
   </test>
 </testlist>

--- a/cime_config/testdefs/testmods_dirs/mosart/negtooutlet/user_nl_mosart
+++ b/cime_config/testdefs/testmods_dirs/mosart/negtooutlet/user_nl_mosart
@@ -1,0 +1,2 @@
+ qgwl_runoff_option = 'negative'
+ bypass_routing_option = 'direct_to_outlet'

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,4 +1,25 @@
 ===============================================================
+Tag name:  mosart1_0_47
+Originator(s): erik
+Date: Nov 12, 2022
+One-line Summary: Some fixes for the direct_to_outlet option
+
+This fixes the balance errors evident in the mosart log file when 
+the bypass_routing_option='direct_to_outlet' method is used.
+Note that these balance errors are warnings and do not stop the model.
+
+Code from @swensosc, PR by @olyson
+
+Fixes #54 -- update cime directory in buildlib/buildnml
+Fixes #56 -- Some issues with the direct_to_outlet option
+
+Also don't allow the threshold option to be set with
+direct_to_outlet is choosen, as well as any option other
+than "all" for "none".
+
+Answers change when direct_to_outlet option is used
+
+===============================================================
 Tag name:  mosart1_0_46
 Originator(s): jedwards
 Date: Jun 12, 2022

--- a/src/riverroute/RtmMod.F90
+++ b/src/riverroute/RtmMod.F90
@@ -1634,7 +1634,7 @@ contains
        cnt = 0
        do nr = rtmCTL%begr,rtmCTL%endr
           cnt = cnt + 1
-          rtmCTL%direct(nr,nt) = avdst_direct%rAttr(nt,cnt)
+          rtmCTL%direct(nr,nt) = rtmCTL%direct(nr,nt) + avdst_direct%rAttr(nt,cnt)
        enddo
     endif
 
@@ -1748,7 +1748,7 @@ contains
        do nr = rtmCTL%begr,rtmCTL%endr
           cnt = cnt + 1
           do nt = 1,nt_rtm
-             rtmCTL%direct(nr,nt) = avdst_direct%rAttr(nt,cnt)
+             rtmCTL%direct(nr,nt) = rtmCTL%direct(nr,nt) + avdst_direct%rAttr(nt,cnt)
           enddo
        enddo
     endif

--- a/src/riverroute/RtmMod.F90
+++ b/src/riverroute/RtmMod.F90
@@ -244,6 +244,12 @@ contains
        endif
     end if
 
+    if (trim(bypass_routing_option) == 'direct_to_outlet') then
+       if (trim(qgwl_runoff_option) == 'threshold') then
+          call shr_sys_abort( subname//' ERROR: bypass_routing_option can NOT be threshold if bypass_routing_option==direct_to_outlet' )
+       end if
+    end if
+
     if (coupling_period <= 0) then
        write(iulog,*) subname,' ERROR MOSART coupling_period invalid',coupling_period
        call shr_sys_abort( subname//' ERROR: coupling_period invalid' )

--- a/src/riverroute/RtmMod.F90
+++ b/src/riverroute/RtmMod.F90
@@ -246,7 +246,11 @@ contains
 
     if (trim(bypass_routing_option) == 'direct_to_outlet') then
        if (trim(qgwl_runoff_option) == 'threshold') then
-          call shr_sys_abort( subname//' ERROR: bypass_routing_option can NOT be threshold if bypass_routing_option==direct_to_outlet' )
+          call shr_sys_abort( subname//' ERROR: qgwl_runoff_option can NOT be threshold if bypass_routing_option==direct_to_outlet' )
+       end if
+    else if (trim(bypass_routing_option) == 'none') then
+       if (trim(qgwl_runoff_option) /= 'all') then
+          call shr_sys_abort( subname//' ERROR: qgwl_runoff_option can only be all if bypass_routing_option==none' )
        end if
     end if
 


### PR DESCRIPTION
This fixes the balance errors evident in the mosart log file when the bypass_routing_option='direct_to_outlet' method is used.
Note that these balance errors are warnings and do not stop the model.
Code from @swensosc 
PR requested by @ekluzek 

Fixes #54 
Fixes #56 

Test case:
/glade/work/oleson/ctsm5.1.dev100/cime/scripts/ctsm51_ctsm51d100_1deg_GSWP3V1_directtooutlet_2000
Note that the test case uses ctsm5.1.dev100 and mosart1_0_45.
Verified that there were no balance errors in the mosart log file.
Testing: Standard mosart test list on cheyenne PASS with expected change in answers for
ERP_D.f10_f10_mg37.I1850Clm50Bgc.cheyenne_intel.mosart-qgrwlOpts

Also don't allow the threshold option to be set with
direct_to_outlet is choosen, as well as any option other
than "all" for "none".

Answers change when direct_to_outlet option is used