### PR TITLE
Make the default to send to outlet for all cases

### DIFF
--- a/cime_config/namelist_definition_mosart.xml
+++ b/cime_config/namelist_definition_mosart.xml
@@ -94,7 +94,7 @@
     <group>mosart_inparm</group>
     <valid_values>direct_in_place,direct_to_outlet,none</valid_values>
     <values>
-      <value>direct_in_place</value>
+      <value>direct_to_outlet</value>
     </values>
     <desc>
       Method for bypassing routing model.
@@ -107,7 +107,7 @@
     <group>mosart_inparm</group>
     <valid_values>all,negative,threshold</valid_values>
     <values>
-      <value>threshold</value>
+      <value>negative</value>
     </values>
     <desc>
       Method for handling of qgwl runoff inputs.

--- a/cime_config/testdefs/testlist_mosart.xml
+++ b/cime_config/testdefs/testlist_mosart.xml
@@ -111,13 +111,22 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="PEM_D" grid="f10_f10_mg37" compset="I1850Clm50Sp" testmods="mosart/negtooutlet">
+  <test name="PEM_D" grid="f10_f10_mg37" compset="I1850Clm50Sp" testmods="mosart/inplacethreshold">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mosart"></machine>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment"  >Set direct_to_outlet for negative flow</option>
+      <option name="comment"  >Set direct_in_place for threshold negative flow</option>
+    </options>
+  </test>
+  <test name="ERI_D" grid="f10_f10_mg37" compset="I1850Clm50Sp" testmods="mosart/nobypass">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="mosart"></machine>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Run without any bypass option</option>
     </options>
   </test>
 </testlist>

--- a/cime_config/testdefs/testlist_mosart.xml
+++ b/cime_config/testdefs/testlist_mosart.xml
@@ -120,7 +120,7 @@
       <option name="comment"  >Set direct_in_place for threshold negative flow</option>
     </options>
   </test>
-  <test name="ERI_D" grid="f10_f10_mg37" compset="I1850Clm50Sp" testmods="mosart/nobypass">
+  <test name="SMS" grid="f10_f10_mg37" compset="I1850Clm50Sp" testmods="mosart/nobypass">
     <machines>
       <machine name="cheyenne" compiler="intel" category="mosart"></machine>
     </machines>

--- a/cime_config/testdefs/testmods_dirs/mosart/inplacethreshold/user_nl_mosart
+++ b/cime_config/testdefs/testmods_dirs/mosart/inplacethreshold/user_nl_mosart
@@ -1,0 +1,2 @@
+ qgwl_runoff_option = 'threshold'
+ bypass_routing_option = 'direct_in_place'

--- a/cime_config/testdefs/testmods_dirs/mosart/negtooutlet/user_nl_mosart
+++ b/cime_config/testdefs/testmods_dirs/mosart/negtooutlet/user_nl_mosart
@@ -1,2 +1,0 @@
- qgwl_runoff_option = 'negative'
- bypass_routing_option = 'direct_to_outlet'

--- a/cime_config/testdefs/testmods_dirs/mosart/nobypass/user_nl_mosart
+++ b/cime_config/testdefs/testmods_dirs/mosart/nobypass/user_nl_mosart
@@ -1,0 +1,2 @@
+ qgwl_runoff_option = 'all'
+ bypass_routing_option = 'none'

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,4 +1,15 @@
 ===============================================================
+Tag name:  mosart1_0_48
+Originator(s): erik
+Date: Nov 13, 2022
+One-line Summary: Change bypass_routing option to direct_to_outlet
+
+Change the bypass_routing option to negative flow is sent to
+the river outlets.
+
+Fixes #58 -- change bypass_routing default
+
+===============================================================
 Tag name:  mosart1_0_47
 Originator(s): erik
 Date: Nov 12, 2022


### PR DESCRIPTION
Make the default for bypass routing to send to outlet always. Previous default was direct in place/threshold. Now it's direct_to_outlet/negative.

Fixes #58