### PR TITLE
'I' fields: now on separate htape; non-'I' flds: time = mid-time_bounds

### DIFF
--- a/src/riverroute/RtmHistFile.F90
+++ b/src/riverroute/RtmHistFile.F90
@@ -490,6 +490,7 @@ contains
     integer :: begrof          ! per-proc beginning land runoff index
     integer :: endrof          ! per-proc ending land runoff index
     integer :: numrtm          ! total number of rtm cells on all procs
+    character(len=1) :: avgflag_temp  ! local copy of rtmhist_avgflag_pertape(t)
     character(len=*),parameter :: subname = 'htape_addfld'
     !-------------------------------------------------------
 
@@ -515,15 +516,24 @@ contains
 
     ! Set time averaging flag based on masterlist setting or
     ! override the default averaging flag with namelist setting
+    ! 'I' (instantaneous) not permitted at this stage because we place 'I'
+    ! fields on their own separate history tape; see "Override" below
     select case (avgflag)
     case (' ')
        tape(t)%hlist(n)%avgflag = masterlist(f)%avgflag(t)
-    case ('A','I','X','M')
+    case ('A','X','M')
        tape(t)%hlist(n)%avgflag = avgflag
     case default
        write(iulog,*) trim(subname),' ERROR: unknown avgflag=', avgflag
        call shr_sys_abort()
     end select
+
+    ! Override this field's avgflag if the namelist has set this tape to
+    ! - instantaneous
+    avgflag_temp = rtmhist_avgflag_pertape(t)
+    if (avgflag_temp == 'I') then
+       tape(t)%hlist(n)%avgflag = avgflag_temp
+    end if
 
   end subroutine htape_addfld
 
@@ -649,7 +659,6 @@ contains
     character(len=256) :: name     ! name of attribute
     character(len=256) :: units    ! units of attribute
     character(len=256) :: str      ! global attribute string
-    character(len=  1) :: avgflag  ! time averaging flag
     character(len=*),parameter :: subname = 'htape_create'
     !-----------------------------------------------------
 
@@ -789,6 +798,7 @@ contains
     integer :: dtime                      ! timestep size
     integer :: yr,mon,day,nbsec           ! year,month,day,seconds components of a date
     integer :: hours,minutes,secs         ! hours,minutes,seconds of hh:mm:ss
+    character(len= 12) :: step_or_bounds  ! string used in long_name of several time variables
     character(len= 10) :: basedate        ! base date (yyyymmdd)
     character(len=  8) :: basesec         ! base seconds
     character(len=  8) :: cdate           ! system date
@@ -824,8 +834,18 @@ contains
 
        dim1id(1) = time_dimid
        str = 'days since ' // basedate // " " // basesec
-       call ncd_defvar(nfid(t), 'time', tape(t)%ncprec, 1, dim1id, varid, &
-            long_name='time',units=str)
+       if (tape(t)%hlist(1)%avgflag /= 'I') then  ! NOT instantaneous fields tape
+          step_or_bounds = 'time_bounds'
+          long_name = 'time at exact middle of ' // step_or_bounds
+          call ncd_defvar(nfid(t), 'time', tape(t)%ncprec, 1, dim1id, varid, &
+               long_name=long_name, units=str)
+          call ncd_putatt(nfid(t), varid, 'bounds', 'time_bounds')
+       else  ! instantaneous fields tape
+          step_or_bounds = 'time step'
+          long_name = 'time at end of ' // step_or_bounds
+          call ncd_defvar(nfid(t), 'time', tape(t)%ncprec, 1, dim1id, varid, &
+               long_name=long_name, units=str)
+       end if
        cal = get_calendar()
        if (      trim(cal) == NO_LEAP_C   )then
           caldesc = "noleap"
@@ -833,23 +853,28 @@ contains
           caldesc = "gregorian"
        end if
        call ncd_putatt(nfid(t), varid, 'calendar', caldesc)
-       call ncd_putatt(nfid(t), varid, 'bounds', 'time_bounds')
 
        dim1id(1) = time_dimid
+       long_name = 'current date (YYYYMMDD) at end of ' // step_or_bounds
        call ncd_defvar(nfid(t) , 'mcdate', ncd_int, 1, dim1id , varid, &
-          long_name = 'current date (YYYYMMDD)')
+          long_name = long_name)
+       long_name = 'current seconds of current date at end of ' // step_or_bounds
        call ncd_defvar(nfid(t) , 'mcsec' , ncd_int, 1, dim1id , varid, &
-          long_name = 'current seconds of current date', units='s')
+          long_name = long_name, units='s')
+       long_name = 'current day (from base day) at end of ' // step_or_bounds
        call ncd_defvar(nfid(t) , 'mdcur' , ncd_int, 1, dim1id , varid, &
-          long_name = 'current day (from base day)')
+          long_name = long_name)
+       long_name = 'current seconds of current day at end of ' // step_or_bounds
        call ncd_defvar(nfid(t) , 'mscur' , ncd_int, 1, dim1id , varid, &
-          long_name = 'current seconds of current day')
+          long_name = long_name)
        call ncd_defvar(nfid(t) , 'nstep' , ncd_int, 1, dim1id , varid, &
           long_name = 'time step')
 
        dim2id(1) = hist_interval_dimid;  dim2id(2) = time_dimid
-       call ncd_defvar(nfid(t), 'time_bounds', ncd_double, 2, dim2id, varid, &
-          long_name = 'history time interval endpoints')
+       if (tape(t)%hlist(1)%avgflag /= 'I') then  ! NOT instantaneous fields tape
+          call ncd_defvar(nfid(t), 'time_bounds', ncd_double, 2, dim2id, varid, &
+             long_name = 'history time interval endpoints')
+       end if
 
        dim2id(1) = strlen_dimid;  dim2id(2) = time_dimid
        call ncd_defvar(nfid(t), 'date_written', ncd_char, 2, dim2id, varid)
@@ -881,12 +906,15 @@ contains
        call ncd_io('mscur' , mscur , 'write', nfid(t), nt=tape(t)%ntimes)
        call ncd_io('nstep' , nstep , 'write', nfid(t), nt=tape(t)%ntimes)
 
-       time = mdcur + mscur/secspday
+       timedata(1) = tape(t)%begtime  ! beginning time
+       timedata(2) = mdcur + mscur / secspday  ! end time
+       if (tape(t)%hlist(1)%avgflag /= 'I') then  ! NOT instantaneous fields tape
+          time = (timedata(1) + timedata(2)) * 0.5_r8
+          call ncd_io('time_bounds', timedata, 'write', nfid(t), nt=tape(t)%ntimes)
+       else
+          time = timedata(2)
+       end if
        call ncd_io('time'  , time  , 'write', nfid(t), nt=tape(t)%ntimes)
-
-       timedata(1) = tape(t)%begtime
-       timedata(2) = time
-       call ncd_io('time_bounds', timedata, 'write', nfid(t), nt=tape(t)%ntimes)
 
        call getdatetime (cdate, ctime)
        call ncd_io('date_written', cdate, 'write', nfid(t), nt=tape(t)%ntimes)


### PR DESCRIPTION
MOSART equivalent to CTSM work done in [#2019](https://github.com/ESCOMP/CTSM/pull/2019/)

Resolves #52 

Not tested.