### PR TITLE
Added code to make st-archive handle DART files

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -4,6 +4,7 @@
     <rest_file_extension>r</rest_file_extension>
     <rest_file_extension>rh\d*</rest_file_extension>
     <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>e</hist_file_extension>
     <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>


### PR DESCRIPTION
This PR fixes #116.
It has been tested in mosart1.1.08-3-gea2074b and cesm3_0_beta03-121-g0a50f32.
The MOSART+DART output files were fake, because there is not yet an interface to create real ones,
but they had the correct names.
Regular MOSART output files were created by an active MOSART component and were archived as usual.