### PR TITLE
this vm is needed for the esmf_aware_threading feature

### DIFF
--- a/src/cpl/nuopc/rof_comp_nuopc.F90
+++ b/src/cpl/nuopc/rof_comp_nuopc.F90
@@ -25,7 +25,8 @@ module rof_comp_nuopc
                                   model_label_DataInitialize => label_DataInitialize, &
                                   model_label_SetRunClock    => label_SetRunClock, &
                                   model_label_Finalize       => label_Finalize, &
-                                  NUOPC_ModelGet
+                                  NUOPC_ModelGet, &
+                                  SetVM
   use shr_kind_mod       , only : R8=>SHR_KIND_R8, CL=>SHR_KIND_CL, CS=>SHR_KIND_CS
   use shr_sys_mod        , only : shr_sys_abort
   use shr_log_mod        , only : shr_log_getlogunit, shr_log_setlogunit
@@ -49,6 +50,7 @@ module rof_comp_nuopc
 
   ! Module routines
   public  :: SetServices
+  public  :: SetVM
   private :: InitializeP0
   private :: InitializeAdvertise
   private :: InitializeRealize


### PR DESCRIPTION
This VM is needed for the cesm3 ESMF_AWARE_THREADING feature.  This feature allows each component to set its number of omp threads independent of all other components.  Without this feature all components must have the same number of threads for correct evolution of the model. 