### PR TITLE
mosart1.1.13: Refactor conditional to work with ifx, which doesn't short-circuit

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,4 +1,20 @@
 <hr>
+# Tag name:  mosart1.1.13
+### Originator(s): billsacks / ekluzek
+### Date: Feb 20, 2026
+### One-line Summary: Fixes needed to work with the ifx compiler
+
+Resolves issue https://github.com/ESCOMP/MOSART/issues/125
+
+Testing: standard testing
+  izumi ---- 
+  derecho -- 
+
+More details in the PRs:
+https://github.com/ESCOMP/MOSART/pull/126
+
+<hr>
+<hr>
 # Tag name:  mosart1.1.12
 ### Originator(s): slevis
 ### Date: Jul 31, 2025

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -7,8 +7,8 @@
 Resolves issue https://github.com/ESCOMP/MOSART/issues/125
 
 Testing: standard testing
-  izumi ---- 
-  derecho -- 
+  izumi ---- PASS
+  derecho -- PASS
 
 More details in the PRs:
 https://github.com/ESCOMP/MOSART/pull/126

--- a/src/riverroute/mosart_tspatialunit_type.F90
+++ b/src/riverroute/mosart_tspatialunit_type.F90
@@ -363,13 +363,14 @@ contains
             if (this%twidth(n) < 0._r8) then
                this%twidth(n) = 0._r8
             end if
-            if ( this%tlen(n) > 0._r8 .and. &
-                 (this%rlenTotal(n)-this%rlen(n))/this%tlen(n) > 1._r8 ) then
-               this%twidth(n) = c_twid(n)*this%twidth(n) * &
-                    ((this%rlenTotal(n)-this%rlen(n))/this%tlen(n))
-            end if
-            if (this%tlen(n) > 0._r8 .and. this%twidth(n) <= 0._r8) then
-               this%twidth(n) = 0._r8
+            if (this%tlen(n) > 0._r8) then
+               if ((this%rlenTotal(n)-this%rlen(n))/this%tlen(n) > 1._r8) then
+                  this%twidth(n) = c_twid(n)*this%twidth(n) * &
+                       ((this%rlenTotal(n)-this%rlen(n))/this%tlen(n))
+               end if
+               if (this%twidth(n) < 0._r8) then
+                  this%twidth(n) = 0._r8
+               end if
             end if
          else
             this%hlen(n) = 0._r8


### PR DESCRIPTION
This also does a bit of other refactoring of the nearby code to clean things up, including changing a <= comparison to < (because we don't need to set twidth to 0 if it's already 0).

Resolves ESCOMP/MOSART#125
Resolves ESCOMP/MOSART#72